### PR TITLE
Fix bug with initialization of core properties

### DIFF
--- a/org.lpe.common.config/src/org/lpe/common/config/GlobalConfiguration.java
+++ b/org.lpe.common.config/src/org/lpe/common/config/GlobalConfiguration.java
@@ -103,7 +103,7 @@ public final class GlobalConfiguration {
 			Properties projectProperties) {
 		if (!initialized) {
 			GlobalConfiguration.coreProperties = new Properties();
-			coreProperties.putAll(coreProperties);
+			GlobalConfiguration.coreProperties.putAll(coreProperties);
 			instance = new GlobalConfiguration(coreProperties,
 					projectProperties);
 			initialized = true;


### PR DESCRIPTION
The static variable was not used but the local variable. Now a call to
reinitialize uses the correct core properties (empty before).

Change-Id: I93d6b6e6228e81b7226fb2f5ef82aef3b112aa31
Signed-off-by: Denis Knoepfle denis.knoepfle@sap.com
